### PR TITLE
Use ssh protocol instead of http to access harvestr tap

### DIFF
--- a/singer-connectors/tap-harvestr/requirements.txt
+++ b/singer-connectors/tap-harvestr/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/alan-eu/pipelinewise-tap-harvestr.git
+git+ssh://git@github.com/alan-eu/pipelinewise-tap-harvestr.git


### PR DESCRIPTION
## Problem

Use ssh protocol to access harvestr tap repo instead of https (git user on EC2 instance was not able to access repo with https)
