### PR TITLE
Use deploy key for tap-harvestr

### DIFF
--- a/singer-connectors/tap-harvestr/requirements.txt
+++ b/singer-connectors/tap-harvestr/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/alan-eu/pipelinewise-tap-harvestr.git
+git+ssh://git@github.com-pipelinewise-tap-harvestr/alan-eu/pipelinewise-tap-harvestr.git


### PR DESCRIPTION
## Problem

use deploy key specified in the .ssh config file to download the pipelinewise tap repo

This requires adding `-pipelinewise-tap-harvestr` to the hostname

See corresponding [PR](https://github.com/alan-eu/alan-containers/pull/237/files) in alan containers.

## Proposed changes

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue._


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
