### PR TITLE
Fernst/update encryption method

### DIFF
--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -473,8 +473,8 @@ select column_name,privacy_properties:turing_strategy:sql::text as sql from "TUR
                         sql_parts_safe_logging.append(f"({sql_safe_logging}) AS {column_name}")
 
             if sql_parts:
-                data_privacy_sql = f'CREATE OR REPLACE TABLE {full_qual_table_name} AS SELECT * EXCLUDE ({",".join(columns)}) ' + ", ".join(sql_parts) + f' FROM {full_qual_table_name}'
-                data_privacy_sql_safe_logging = f'CREATE OR REPLACE TABLE {full_qual_table_name} AS SELECT * EXCLUDE ({",".join(columns)}) ' + ", ".join(sql_parts_safe_logging) + f' FROM {full_qual_table_name}'
+                data_privacy_sql = f'CREATE OR REPLACE TABLE {full_qual_table_name} AS SELECT * EXCLUDE ({",".join(columns)}), ' + ", ".join(sql_parts) + f' FROM {full_qual_table_name}'
+                data_privacy_sql_safe_logging = f'CREATE OR REPLACE TABLE {full_qual_table_name} AS SELECT * EXCLUDE ({",".join(columns)}), ' + ", ".join(sql_parts_safe_logging) + f' FROM {full_qual_table_name}'
                 LOGGER.info('Running data privacy obfuscation query: %s', data_privacy_sql_safe_logging)
                 self.query(
                     data_privacy_sql,

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -473,8 +473,8 @@ select column_name,privacy_properties:turing_strategy:sql::text as sql from "TUR
                         sql_parts_safe_logging.append(f"({sql_safe_logging}) AS {column_name}")
 
             if sql_parts:
-                data_privacy_sql = f'CREATE OR REPLACE TABLE {full_qual_table_name} AS SELECT * EXCLUDE ({",".join(columns)}), ' + ", ".join(sql_parts) + f' FROM {full_qual_table_name}'
-                data_privacy_sql_safe_logging = f'CREATE OR REPLACE TABLE {full_qual_table_name} AS SELECT * EXCLUDE ({",".join(columns)}), ' + ", ".join(sql_parts_safe_logging) + f' FROM {full_qual_table_name}'
+                data_privacy_sql = f'CREATE OR REPLACE TABLE {full_qual_table_name} AS SELECT * EXCLUDE ({",".join(all_columns)}), ' + ", ".join(sql_parts) + f' FROM {full_qual_table_name}'
+                data_privacy_sql_safe_logging = f'CREATE OR REPLACE TABLE {full_qual_table_name} AS SELECT * EXCLUDE ({",".join(all_columns)}), ' + ", ".join(sql_parts_safe_logging) + f' FROM {full_qual_table_name}'
                 LOGGER.info('Running data privacy obfuscation query: %s', data_privacy_sql_safe_logging)
                 self.query(
                     data_privacy_sql,


### PR DESCRIPTION
## Problem

_Describe the problem your PR is trying to solve_

If an encryption method changes the type of a column (from `VARIANT` to `VARCHAR` for example), then `UPDATE "MY_TABLE" SET "MY_COLUMN" = (sql)` will fail because types are not compatible.

Instead, this query will work:
```sql
CREATE OR REPLACE TABLE "MY_TABLE" AS
SELECT * EXCLUDE ("MY_COLUMN")
     , (sql) AS "MY_COLUMN"
FROM "MY_TABLE"
```

A quick test on `backend.user` (~1M rows) doesn't show any slowdown.